### PR TITLE
identify left and right spacebar in matrix and US ribbon cable pins

### DIFF
--- a/keyboard/sculpt/README.md
+++ b/keyboard/sculpt/README.md
@@ -14,7 +14,13 @@ Move to this directory and run `make`:
     $ make
 
 ## Matrix
-Only keyboard with US layout was traced.
+Only keyboard with US layout was traced. The US matrix ribbon cable had the following writing:
+
+SN5822 US 852-41441-00A V0.4 GODA-3 130601
+
+The US controller PCB had the following writing:
+
+SK3360 V1.1 2013/03/18 812-01311-00A KB-6160 E157925
 
 ### Original US layout keyboard matrix
 Original US layout keboard matrix is 8 rows and 18 columns:
@@ -27,7 +33,7 @@ Original US layout keboard matrix is 8 rows and 18 columns:
     4        SLCK         ENT  SCLN     L           K  BSLS  -->
     5                     APP  SLSH  QUOT  RALT        LEFT  -->
     6        END   RSFT  PGDN         DOT        COMM        --> 
-    7  LCTL  RGHT          UP  DOWN                     SPC  -->
+    7  LCTL  RGHT          UP  DOWN                    RSPC  -->
     8        PSCR         F11   EQL    F9          F8   F10  -->
 
                           J     K     L     M     N     O     P     Q     R
@@ -38,13 +44,52 @@ Original US layout keboard matrix is 8 rows and 18 columns:
                   -->     J     F     D           A        LGUI              4
                   -->     H     G    F4     S   ESC              LALT        5
                   -->     M     V     C     X     Z  LSFT                    6
-                  -->     N     B   SPC                                RCTL  7
+                  -->     N     B  LSPC                                RCTL  7
                   -->    F7     5    F2    F1   GRV           6              8
 
 Note that original matrix requires 8+18=26 pins on micro-controller and will
 not work verbatim on Teensy 2.0 because it only has 25 pins.
 
-### Modified US layout keyboard matrix 
+### Original US layout flex cable pinout
+
+There are 30 pins on the US layout Sculpt flex cable. Pin 1 is the outermost
+pin (closest to the rounded corner with the writing) and lines up with the
+pin marked "1" underneath a triangle on the US controller PCB.
+
+| Pin | Matrix Connection        |
+| --- | ------------------------ |
+| 1   | Fn Switch                |
+| 2   | row 1                    |
+| 3   | row 2                    |
+| 4   | row 3                    |
+| 5   | row 4                    |
+| 6   | row 5                    |
+| 7   | row 6                    |
+| 8   | row 7                    |
+| 9   | row 8                    |
+| 10  | col A                    |
+| 11  | col B                    |
+| 12  | col C                    |
+| 13  | col D                    |
+| 14  | col E                    |
+| 15  | col F                    |
+| 16  | col G                    |
+| 17  | col H                    |
+| 18  | col I                    |
+| 19  | col J                    |
+| 20  | col K                    |
+| 21  | col L                    |
+| 22  | col M                    |
+| 23  | col N                    |
+| 24  | col O                    |
+| 25  | col P                    |
+| 26  | col Q                    |
+| 27  | col R                    |
+| 28  | n/a (Q2 LED)             |
+| 29  | n/a (Q1 LED)             |
+| 30  | GND (LEDs and fn switch) |
+
+### Modified US layout keyboard matrix
 
 To make all keys work on Teensy 2.0 it is best to merge keys on column C and G
 of orininal matrix (see above). To achieve that simply connect colums C and G
@@ -60,7 +105,7 @@ Modified matrix will have 8 rows and 17 columns and will require 25 pins:
     4        SLCK         ENT  SCLN     L     K  BSLS  -->
     5              RALT   APP  SLSH  QUOT        LEFT  -->
     6        END   RSFT  PGDN         DOT  COMM        --> 
-    7  LCTL  RGHT          UP  DOWN               SPC  -->
+    7  LCTL  RGHT          UP  DOWN              RSPC  -->
     8        PSCR         F11   EQL    F9    F8   F10  -->
 
                           I     J     K     L     M     N     O     P     Q
@@ -71,7 +116,7 @@ Modified matrix will have 8 rows and 17 columns and will require 25 pins:
                   -->     J     F     D           A        LGUI              4
                   -->     H     G    F4     S   ESC              LALT        5
                   -->     M     V     C     X     Z  LSFT                    6
-                  -->     N     B   SPC                                RCTL  7
+                  -->     N     B  LSPC                                RCTL  7
                   -->    F7     5    F2    F1   GRV           6              8
 
 Note that RALT and RSFT are now sitting on the same column (C).


### PR DESCRIPTION
I'm not sure if you'd be interested in this but I traced the US ribbon cable on a broken Sculpt in order to know how to connect the Teensy 2.0 pins. I also identified the different left and right spacebar buttons in the matrix.

This might be useful to others who want to use your code but don't know which ribbon cable pins should go to which Teensy pins.

My ultimate goal is to update your project to use the latest TMK upstream and implement the hardware fn switch so it behaves mostly like stock.